### PR TITLE
fix(cert-manager): use release namespace for leader election

### DIFF
--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -15,3 +15,6 @@ helmCharts:
   repo: https://charts.jetstack.io
   valuesInline:
     installCRDs: true
+    global:
+      leaderElection:
+        namespace: cert-manager


### PR DESCRIPTION
Error seen in `cert-manager` Deployment:
```
User "system:serviceaccount:cert-manager:cert-manager" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
```

Context: https://github.com/cert-manager/cert-manager/issues/6716